### PR TITLE
fix(livereload): Images not loading

### DIFF
--- a/src/providers/image-loader.ts
+++ b/src/providers/image-loader.ts
@@ -414,11 +414,18 @@ export class ImageLoader {
    * @returns {Promise<string>} Returns a promise that resolves with the local path if exists, or rejects if doesn't exist
    */
   private getCachedImagePath(url: string): Promise<string> {
+    // Check if we're running with livereload
+    let _isDev: boolean = (window['IonicDevServer'] != undefined);
     return new Promise<string>((resolve, reject) => {
 
       // make sure cache is ready
       if (!this.isCacheReady) {
         return reject();
+      }
+      
+      // if we're running with livereload, ignore cache and call the resource from it's URL
+      if(!!_isDev){
+          return reject();
       }
 
       // get file name


### PR DESCRIPTION
When running in an emulator or in a device with the flag --livereload images were not showing.